### PR TITLE
Update COSC344 ASSIGNMENT 2.md

### DIFF
--- a/COSC344 ASSIGNMENT 2.md
+++ b/COSC344 ASSIGNMENT 2.md
@@ -254,6 +254,16 @@ Definition: 3NF and for every non-trivial functional dependency X->A, X is a sup
 | <u>Street_Name</u> | <u>Suburb</u> | Postcode |
 | ----------- | ----------- | ----------- |
 
+##### Department
+
+| <u>Name</u> | Number_Of_Academic_Staff | Number_Of_Nonacademic_Staff |
+| ----------- | ------------------------ | --------------------------- |
+
+##### Course 
+
+| <u>Name</u> | Years_Required | Level |
+| ----------- | -------------- | ------------- |
+
 ### Dept_Based_In_Building
 | <u>Dept_Name</u><br>(REFERENCES Department) | <u>Street_Number</u><br>(REFERENCES Building) | <u>Street_Name</u><br>(REFERENCES Building)  | <u>Suburb</u><br>(REFERENCES Building)  |
 | ----------- | ----------- | ----------- | ----------- |
@@ -261,5 +271,19 @@ Definition: 3NF and for every non-trivial functional dependency X->A, X is a sup
 ### Paper_Lectured_In_Room
 | <u>Paper_Code</u><br>(REFERENCES Paper) | <u>Street_Number</u><br>(REFERENCES Building) | <u>Street_Name</u><br>(REFERENCES Building)  | <u>Suburb</u><br>(REFERENCES Building)  | <u> Room Number</u> |
 | ----------- | ----------- | ----------- | ----------- |----------- |
+
+##### Staff_Member_Works_For_Department
+| <u>Staff_Member_Id</u><br>(REFERENCES Staff) | <u>Department_Name</u><br>(REFERENCES Department) |
+| -------------------------------------------- | ------------------------------------------------- |
+
+##### Paper_Counts_Toward_Course
+| <u>Paper_Code</u><br>(REFERENCES Paper) | <u>Course_Name</u><br>(REFERENCES Course) |
+| --------------------------------------- | ----------------------------------------- |
+
+
+##### Department_Offers_Major_For_Course
+| <u>Department_Name</u><br>(REFERENCES Department) | <u>Course_Name</u><br>(REFERENCES Course) |
+| ------------------------------------------------- | ----------------------------------------- |
+
 
 


### PR DESCRIPTION
Nat's normalization. As far as I can tell, most of my relations were already in BCNF (but that could just be wishful thinking; please correct me if I'm wrong!). The only exception was the Course entity, which had an undergraduate attribute and a postgraduate attribute. Assuming that a course must be either for undergraduates or postgraduates (and not both), there seems to be a transitive dependency (i.e., if a course changes the boolean value for its undergraduate attribute, the boolean value for its postgraduate attribute must also change). However, I'm not sure if the recommended step (removing transitive dependencies into a new relation) is appropriate here. I'd prefer to revise the ER diagram in step 1 of the assignment so that course has a "level" attribute instead of an undergraduate and a postgraduate attribute. Maybe we can discuss this later in the meeting?